### PR TITLE
Improve world checking

### DIFF
--- a/src/us/Myles/PWP/PWPCommandExecutor.java
+++ b/src/us/Myles/PWP/PWPCommandExecutor.java
@@ -14,8 +14,7 @@ public class PWPCommandExecutor implements CommandExecutor {
 				sender.sendMessage(Plugin.color("&c[&4PWP&c] &fUsage: &7/pwp reload|version"));
 			} else {
 				if (args[0].equalsIgnoreCase("reload")) {
-					Plugin.instance.reloadConfig();
-					Plugin.instance.loadConfig();
+					Plugin.instance.reload();
 					sender.sendMessage(Plugin.color("&a[&2PWP&a] &fPerWorldPlugins successfully reloaded!"));
 					if (sender instanceof Player){
 						Player p = (Player) sender;


### PR DESCRIPTION
Frequently called events will have a visible impact on TPS because of the many string comparisons in `public boolean checkWorld(org.bukkit.plugin.Plugin plugin, World w)`. This fix loads the file configuration into a table once per load/reload so checking is faster.

Images showing impact of fix: [http://imgur.com/a/h8g0I](http://imgur.com/a/h8g0I)
